### PR TITLE
Separate file and stream log levels

### DIFF
--- a/cppwg/__main__.py
+++ b/cppwg/__main__.py
@@ -120,21 +120,29 @@ def main() -> None:
     """Generate wrappers from command line arguments."""
     args = parse_args()
 
-    log_handlers = [logging.StreamHandler()]
+    log_handlers = []
+
+    # Set up logging
+    stream_handler = logging.StreamHandler()
+    if args.quiet:
+        stream_handler.setLevel(logging.ERROR)
+    else:
+        stream_handler.setLevel(logging.INFO)
+    log_handlers.append(stream_handler)
+
     if args.logfile:
-        log_handlers.append(logging.FileHandler(args.logfile))
+        file_handler = logging.FileHandler(args.logfile, "w+")
+        file_handler.setLevel(logging.INFO)
+        log_handlers.append(file_handler)
 
     logging.basicConfig(
         format="%(levelname)s %(message)s",
         handlers=log_handlers,
     )
     logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
 
-    if args.quiet:
-        logger.setLevel(logging.ERROR)
-    else:
-        logger.setLevel(logging.INFO)
-
+    # Generate the wrappers
     generate(args)
 
 

--- a/cppwg/generators.py
+++ b/cppwg/generators.py
@@ -99,9 +99,9 @@ class CppWrapperGenerator:
         logger.info(f"pygccxml version {pygccxml.__version__}")
 
         # Sanitize castxml_cflags
-        self.castxml_cflags: str = ""
+        self.castxml_cflags = "-w"
         if castxml_cflags:
-            self.castxml_cflags = castxml_cflags
+            self.castxml_cflags = f"{self.castxml_cflags} {castxml_cflags}"
 
         # Sanitize source_root
         self.source_root: str = os.path.abspath(source_root)


### PR DESCRIPTION
**Summary**
* Stream logging level depends on `--quiet` flag.
* File logging level is always `INFO`.
* Overwrite log files.
* Disable warnings from `castxml`.