### PR TITLE
Unify argument and return type exclusion options

### DIFF
--- a/cppwg/info/base_info.py
+++ b/cppwg/info/base_info.py
@@ -270,6 +270,11 @@ class BaseInfo(ABC):
         across all levels (e.g. all exclude patterns from class, module and
         package).
 
+        Only actual sequences (list/tuple/set) are flattened; any other value
+        (e.g. a yaml `option: foo` written instead of the expected
+        `option: [foo]`) is treated as a single item rather than being iterated
+        - which for a str would split it into individual characters.
+
         Parameters
         ----------
         attribute_name : str
@@ -280,8 +285,10 @@ class BaseInfo(ABC):
         list[Any]
             The flattened list of items.
         """
-        return [
-            item
-            for value in self.hierarchy_attribute_gather(attribute_name)
-            for item in value
-        ]
+        flat: list[Any] = []
+        for value in self.hierarchy_attribute_gather(attribute_name):
+            if isinstance(value, (list, tuple, set)):
+                flat.extend(value)
+            else:
+                flat.append(value)
+        return flat

--- a/cppwg/info/base_info.py
+++ b/cppwg/info/base_info.py
@@ -24,11 +24,17 @@ class BaseInfo(ABC):
     Attributes
     ----------
     arg_type_excludes : list[str]
-        List of exclude patterns for arg types in methods.
+        Exclude any method or constructor with an argument of one of these
+        types. Patterns match a type as a whole token (so `Node` does not match
+        `AbstractNode`).
     calldef_excludes : list[str]
-        Do not include calldefs matching these patterns.
+        Deprecated: use arg_type_excludes and/or return_type_excludes. Kept for
+        backwards compatibility; treated as both arg_type_excludes and
+        return_type_excludes.
     constructor_arg_type_excludes : list[str]
-        List of exclude patterns for arg types in constructors.
+        Exclude constructors (only) with an argument of one of these types, for
+        the case where a type should be excluded from constructors but not
+        methods. Matched the same way as arg_type_excludes.
     constructor_signature_excludes : list[list[str]]
         List of exclude patterns for constructor signatures.
     custom_generator : str
@@ -252,3 +258,29 @@ class BaseInfo(ABC):
 
         value_list.extend(self.parent.hierarchy_attribute_gather(attribute_name))
         return value_list
+
+    def hierarchy_attribute_gather_flat(self, attribute_name: str) -> list[Any]:
+        """
+        Gather a list-valued attribute across the info tree, flattened one level.
+
+        hierarchy_attribute_gather returns one entry per hierarchy level that
+        defines the attribute; for a list-valued option each entry is itself a
+        list. This flattens those into a single list of the option's items
+        across all levels (e.g. all exclude patterns from class, module and
+        package).
+
+        Parameters
+        ----------
+        attribute_name : str
+            The attribute name to search for.
+
+        Returns
+        -------
+        list[Any]
+            The flattened list of items.
+        """
+        return [
+            item
+            for value in self.hierarchy_attribute_gather(attribute_name)
+            for item in value
+        ]

--- a/cppwg/info/base_info.py
+++ b/cppwg/info/base_info.py
@@ -24,9 +24,9 @@ class BaseInfo(ABC):
     Attributes
     ----------
     arg_type_excludes : list[str]
-        Exclude any method or constructor with an argument of one of these
-        types. Patterns match a type as a whole token (so `Node` does not match
-        `AbstractNode`).
+        Exclude any method, constructor or free function with an argument of one
+        of these types. Patterns match a type as a whole token (so `Node` does
+        not match `AbstractNode`).
     calldef_excludes : list[str]
         Deprecated: use arg_type_excludes and/or return_type_excludes. Kept for
         backwards compatibility; treated as both arg_type_excludes and
@@ -60,7 +60,8 @@ class BaseInfo(ABC):
     reference_call_policy : str
         The default reference call policy.
     return_type_excludes : list[str]
-        List of exclude patterns for return types.
+        Exclude any method or free function returning one of these types.
+        Matched the same way as arg_type_excludes.
     smart_ptr_type : str
         Handle classes with this smart pointer type.
     source_includes : list[str]

--- a/cppwg/info/base_info.py
+++ b/cppwg/info/base_info.py
@@ -73,8 +73,8 @@ class BaseInfo(ABC):
     template_substitutions : list[dict[str, Any]]
         A list of template substitution sequences.
 
-    custom_generator_instance : cppwg.templates.custom.Custom
-        An instance of the custom generator class.
+    custom_generator_instance : cppwg.templates.custom.Custom | None
+        An instance of the custom generator class, or None if not set.
     """
 
     def __init__(self, name: str, info_config: dict[str, Any] | None = None) -> None:
@@ -129,10 +129,11 @@ class BaseInfo(ABC):
         # Custom Code
         self.extra_code: list[str] = []
         self.prefix_code: list[str] = []
+        self.suffix_code: list[str] = []
         self.prefix_text: str = ""
         self.custom_generator: str = ""
 
-        self.custom_generator_instance: "Custom" = None
+        self.custom_generator_instance: "Custom | None" = None
 
         if info_config:
             for key in [

--- a/cppwg/info/class_info.py
+++ b/cppwg/info/class_info.py
@@ -55,13 +55,7 @@ class CppClassInfo(CppEntityInfo):
 
         # Get list of template substitutions applicable to this class
         # e.g. [ {"signature":"<int A, int B>", "replacement":[[2,2], [3,3]]} ]
-        substitutions = [
-            ts_dict
-            for ts_dict_list in self.hierarchy_attribute_gather(
-                "template_substitutions"
-            )
-            for ts_dict in ts_dict_list
-        ]
+        substitutions = self.hierarchy_attribute_gather_flat("template_substitutions")
 
         # Skip if there are no applicable template substitutions
         if not substitutions:

--- a/cppwg/info/class_info.py
+++ b/cppwg/info/class_info.py
@@ -70,6 +70,16 @@ class CppClassInfo(CppEntityInfo):
 
         # Search for template signatures in the source file
         for substitution in substitutions:
+            # Skip a mis-typed entry: each substitution must be a dict with a
+            # signature and a replacement (a yaml scalar or malformed entry
+            # would otherwise raise here).
+            if (
+                not isinstance(substitution, dict)
+                or "signature" not in substitution
+                or "replacement" not in substitution
+            ):
+                continue
+
             # Signature e.g. <int A, int B>
             signature = substitution["signature"].strip()
 

--- a/cppwg/info/class_info.py
+++ b/cppwg/info/class_info.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import re
 from typing import TYPE_CHECKING, Any
 
 from pygccxml.declarations.matchers import access_type_matcher_t
@@ -143,19 +142,18 @@ class CppClassInfo(CppEntityInfo):
             return False
 
         query = access_type_matcher_t("public")
-        name_regex = re.compile(r"\b" + re.escape(other.name) + r"\b")
 
         for class_decl in self.decls:
             method_decls = class_decl.member_functions(function=query, allow_empty=True)
             for method_decl in method_decls:
                 for arg_type in method_decl.argument_types:
-                    if name_regex.search(arg_type.decl_string):
+                    if utils.type_string_matches(arg_type.decl_string, other.name):
                         return True
 
             ctor_decls = class_decl.constructors(function=query, allow_empty=True)
             for ctor_decl in ctor_decls:
                 for arg_type in ctor_decl.argument_types:
-                    if name_regex.search(arg_type.decl_string):
+                    if utils.type_string_matches(arg_type.decl_string, other.name):
                         return True
         return False
 

--- a/cppwg/parsers/package_info_parser.py
+++ b/cppwg/parsers/package_info_parser.py
@@ -52,8 +52,12 @@ class PackageInfoParser:
         with open(self.config_file) as config_file:
             raw_package_info = yaml.safe_load(config_file)
 
+        # Warn about any deprecated options present anywhere in the raw config
+        self.warn_deprecated_options(raw_package_info)
+
         # Base config options that apply to package, modules, classes, etc.
         base_config: dict[str, Any] = {
+            "arg_type_excludes": "",
             "calldef_excludes": "",
             "constructor_arg_type_excludes": "",
             "constructor_signature_excludes": "",
@@ -255,6 +259,46 @@ class PackageInfoParser:
                         module_info.add_variable(variable_info)
 
         return package_info
+
+    # Deprecated config option -> replacement guidance shown in the warning.
+    DEPRECATED_OPTIONS = {
+        "calldef_excludes": "use arg_type_excludes and/or return_type_excludes",
+    }
+
+    def warn_deprecated_options(self, raw_config: Any) -> None:
+        """
+        Emit a one-time warning for each deprecated option in the raw config.
+
+        Recursively scans the loaded yaml (which nests modules, classes, free
+        functions and variables) for deprecated option keys and logs a warning
+        once per key found.
+
+        Parameters
+        ----------
+        raw_config : Any
+            The raw parsed yaml structure.
+        """
+        logger = logging.getLogger()
+
+        found: set[str] = set()
+
+        def scan(obj: Any) -> None:
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    if key in self.DEPRECATED_OPTIONS:
+                        found.add(key)
+                    scan(value)
+            elif isinstance(obj, list):
+                for item in obj:
+                    scan(item)
+
+        scan(raw_config)
+
+        for key in sorted(found):
+            logger.warning(
+                f"Config option '{key}' is deprecated; "
+                f"{self.DEPRECATED_OPTIONS[key]}."
+            )
 
     def convert_custom_generator(self, config: dict[str, Any]) -> None:
         """

--- a/cppwg/parsers/package_info_parser.py
+++ b/cppwg/parsers/package_info_parser.py
@@ -57,10 +57,10 @@ class PackageInfoParser:
 
         # Base config options that apply to package, modules, classes, etc.
         base_config: dict[str, Any] = {
-            "arg_type_excludes": "",
-            "calldef_excludes": "",
-            "constructor_arg_type_excludes": "",
-            "constructor_signature_excludes": "",
+            "arg_type_excludes": [],
+            "calldef_excludes": [],
+            "constructor_arg_type_excludes": [],
+            "constructor_signature_excludes": [],
             "custom_generator": "",
             "excluded": False,
             "excluded_methods": [],
@@ -70,7 +70,7 @@ class PackageInfoParser:
             "prefix_code": [],
             "prefix_text": "",
             "reference_call_policy": "",
-            "return_type_excludes": "",
+            "return_type_excludes": [],
             "smart_ptr_type": "",
             "source_includes": [],
             "source_root": self.source_root,

--- a/cppwg/utils/utils.py
+++ b/cppwg/utils/utils.py
@@ -87,6 +87,11 @@ def is_option_ALL(input_obj: Any) -> bool:
     return isinstance(input_obj, str) and input_obj.upper() == CPPWG_ALL_STRING
 
 
+# A single C++ identifier character, used to decide where identifier boundaries
+# apply when matching type patterns.
+_IDENTIFIER_CHAR = re.compile(r"[A-Za-z0-9_]")
+
+
 def type_string_matches(type_string: str, pattern: str) -> bool:
     """
     Check whether a type pattern occurs in a C++ type string as a whole token.
@@ -115,7 +120,14 @@ def type_string_matches(type_string: str, pattern: str) -> bool:
     if not isinstance(pattern, str) or not pattern:
         return False
 
-    regex = r"(?<![A-Za-z0-9_])" + re.escape(pattern) + r"(?![A-Za-z0-9_])"
+    # Enforce an identifier boundary only on an edge whose pattern character is
+    # itself an identifier character. A pattern ending in e.g. > / * / & should
+    # still match when immediately followed by a letter, as in
+    # "std::vector<int>const &".
+    left = r"(?<![A-Za-z0-9_])" if _IDENTIFIER_CHAR.match(pattern[0]) else ""
+    right = r"(?![A-Za-z0-9_])" if _IDENTIFIER_CHAR.match(pattern[-1]) else ""
+
+    regex = left + re.escape(pattern) + right
     return re.search(regex, type_string) is not None
 
 

--- a/cppwg/utils/utils.py
+++ b/cppwg/utils/utils.py
@@ -87,6 +87,36 @@ def is_option_ALL(input_obj: Any) -> bool:
     return isinstance(input_obj, str) and input_obj.upper() == CPPWG_ALL_STRING
 
 
+def type_string_matches(type_string: str, pattern: str) -> bool:
+    """
+    Check whether a type pattern occurs in a C++ type string as a whole token.
+
+    The match respects identifier boundaries so a pattern is not matched as part
+    of a larger identifier: ``Node`` matches ``::Node<2> const &`` but not
+    ``AbstractNode``. Patterns whose edges are not identifier characters (e.g.
+    ending in ``*`` or ``&``) are matched literally at those edges. This is used
+    to decide whether a method/constructor argument or return type should be
+    excluded from wrapping.
+
+    Parameters
+    ----------
+    type_string : str
+        The C++ type string to search (e.g. a pygccxml decl_string).
+    pattern : str
+        The type pattern to look for.
+
+    Returns
+    -------
+    bool
+        True if the pattern occurs in the type string as a whole token.
+    """
+    if not pattern:
+        return False
+
+    regex = r"(?<![A-Za-z0-9_])" + re.escape(pattern) + r"(?![A-Za-z0-9_])"
+    return re.search(regex, type_string) is not None
+
+
 def find_classes_in_source(
     source: str,
     class_name: str = None,

--- a/cppwg/utils/utils.py
+++ b/cppwg/utils/utils.py
@@ -110,7 +110,9 @@ def type_string_matches(type_string: str, pattern: str) -> bool:
     bool
         True if the pattern occurs in the type string as a whole token.
     """
-    if not pattern:
+    # A non-string pattern (e.g. a yaml scalar like `arg_type_excludes: 5`) is
+    # not a valid type pattern; treat it as non-matching rather than crashing.
+    if not isinstance(pattern, str) or not pattern:
         return False
 
     regex = r"(?<![A-Za-z0-9_])" + re.escape(pattern) + r"(?![A-Za-z0-9_])"

--- a/cppwg/writers/class_writer.py
+++ b/cppwg/writers/class_writer.py
@@ -110,7 +110,10 @@ class CppClassWrapperWriter(CppBaseWrapperWriter):
         )
 
         for source_include in source_includes:
-            if source_include[0] == "<":
+            # Skip a mis-typed non-string (or empty) entry, e.g. a yaml scalar.
+            if not isinstance(source_include, str) or not source_include:
+                continue
+            if source_include.startswith("<"):
                 # e.g. #include <string>
                 includes += f"#include {source_include}\n"
             else:
@@ -255,6 +258,11 @@ class CppClassWrapperWriter(CppBaseWrapperWriter):
 
         allow_external_bases = bool(self.class_info.hierarchy_attribute("imports"))
         external_bases = self.class_info.hierarchy_attribute("external_bases") or []
+        # Normalize a mis-typed scalar (e.g. `external_bases: AbstractFoo`) to a
+        # list, otherwise the `... in external_bases` test below would match on
+        # substrings (e.g. "Foo" in "AbstractFoo").
+        if isinstance(external_bases, str):
+            external_bases = [external_bases]
 
         for base in class_decl.bases:  # type(base) -> hierarchy_info_t
             # Check that the base class is not private

--- a/cppwg/writers/class_writer.py
+++ b/cppwg/writers/class_writer.py
@@ -257,12 +257,15 @@ class CppClassWrapperWriter(CppBaseWrapperWriter):
         bases = ""
 
         allow_external_bases = bool(self.class_info.hierarchy_attribute("imports"))
-        external_bases = self.class_info.hierarchy_attribute("external_bases") or []
-        # Normalize a mis-typed scalar (e.g. `external_bases: AbstractFoo`) to a
-        # list, otherwise the `... in external_bases` test below would match on
-        # substrings (e.g. "Foo" in "AbstractFoo").
+        external_bases = self.class_info.hierarchy_attribute("external_bases")
         if isinstance(external_bases, str):
+            # A scalar (e.g. `external_bases: AbstractFoo`) is a single base
+            # name; wrap it so the membership test below is exact rather than a
+            # substring match (e.g. "Foo" in "AbstractFoo").
             external_bases = [external_bases]
+        elif not isinstance(external_bases, (list, tuple, set)):
+            # Unset (None) or any other mis-typed scalar -> no external bases.
+            external_bases = []
 
         for base in class_decl.bases:  # type(base) -> hierarchy_info_t
             # Check that the base class is not private

--- a/cppwg/writers/class_writer.py
+++ b/cppwg/writers/class_writer.py
@@ -105,13 +105,9 @@ class CppClassWrapperWriter(CppBaseWrapperWriter):
 
         includes = ""
 
-        source_includes = [
-            inc
-            for inc_list in self.class_info.hierarchy_attribute_gather(
-                "source_includes"
-            )
-            for inc in inc_list
-        ]
+        source_includes = self.class_info.hierarchy_attribute_gather_flat(
+            "source_includes"
+        )
 
         for source_include in source_includes:
             if source_include[0] == "<":

--- a/cppwg/writers/constructor_writer.py
+++ b/cppwg/writers/constructor_writer.py
@@ -135,6 +135,13 @@ class CppConstructorWrapperWriter(CppBaseWrapperWriter):
             "constructor_signature_excludes"
         )
         for exclude_types in ctor_signature_excludes:
+            # Each entry must be a sequence of per-argument patterns. Skip a
+            # mis-typed scalar (e.g. `constructor_signature_excludes: 5`, or a
+            # single string), which would otherwise crash on len() or be
+            # iterated character by character.
+            if not isinstance(exclude_types, (list, tuple)):
+                continue
+
             if len(exclude_types) != len(arg_types):
                 continue
 

--- a/cppwg/writers/constructor_writer.py
+++ b/cppwg/writers/constructor_writer.py
@@ -102,62 +102,44 @@ class CppConstructorWrapperWriter(CppBaseWrapperWriter):
         ):
             return True
 
-        # Get arg type strings with spaces removed
-        # e.g. ::std::vector<unsigned int> const & -> ::std::vector<unsignedint>const&
-        arg_types = [
-            x.decl_string.replace(" ", "") for x in self.ctor_decl.argument_types
-        ]
+        # Argument type strings (canonical, as spelled by pygccxml)
+        arg_types = [x.decl_string for x in self.ctor_decl.argument_types]
 
         # Exclude constructors with "iterator" in args
         for arg_type in arg_types:
             if "iterator" in arg_type.lower():
                 return True
 
-        # Exclude constructors with args matching patterns in calldef_excludes
-        calldef_excludes = [
-            ex
-            for ex_list in self.class_info.hierarchy_attribute_gather(
-                "calldef_excludes"
-            )
-            for ex in ex_list
-        ]
-        calldef_excludes = [ex.replace(" ", "") for ex in calldef_excludes]
-        for arg_type in arg_types:
-            if arg_type in calldef_excludes:
-                return True
-
-        # Exclude constructors with args matching patterns in constructor_arg_type_excludes
-        ctor_arg_type_excludes = [
-            ex
-            for ex_list in self.class_info.hierarchy_attribute_gather(
+        # Exclude by argument type. arg_type_excludes is the general arg-type
+        # exclude (methods and constructors); constructor_arg_type_excludes is a
+        # constructor-only refinement; the deprecated calldef_excludes applies
+        # too. All are matched the same (boundary-aware) way.
+        arg_type_excludes = (
+            self.class_info.hierarchy_attribute_gather_flat("arg_type_excludes")
+            + self.class_info.hierarchy_attribute_gather_flat(
                 "constructor_arg_type_excludes"
             )
-            for ex in ex_list
-        ]
-        ctor_arg_type_excludes = [ex.replace(" ", "") for ex in ctor_arg_type_excludes]
-        for exclude_type in ctor_arg_type_excludes:
-            for arg_type in arg_types:
-                if exclude_type in arg_type:
-                    return True
+            + self.class_info.hierarchy_attribute_gather_flat("calldef_excludes")
+        )
+        for arg_type in arg_types:
+            if any(
+                utils.type_string_matches(arg_type, pattern)
+                for pattern in arg_type_excludes
+            ):
+                return True
 
-        # Exclude constructors matching a signature in constructor_signature_excludes
-        ctor_signature_excludes = [
-            ex
-            for ex_list in self.class_info.hierarchy_attribute_gather(
-                "constructor_signature_excludes"
-            )
-            for ex in ex_list
-        ]
-
+        # Exclude constructors matching a full signature in
+        # constructor_signature_excludes: same arity, and each argument type
+        # matches its positional pattern.
+        ctor_signature_excludes = self.class_info.hierarchy_attribute_gather_flat(
+            "constructor_signature_excludes"
+        )
         for exclude_types in ctor_signature_excludes:
             if len(exclude_types) != len(arg_types):
                 continue
 
-            # arg_types are already despaced above, so despace each signature
-            # pattern too, otherwise a pattern with spaces (e.g. "unsigned int")
-            # could never match.
             if all(
-                exclude_type.replace(" ", "") in arg_type
+                utils.type_string_matches(arg_type, exclude_type)
                 for arg_type, exclude_type in zip(arg_types, exclude_types)
             ):
                 return True

--- a/cppwg/writers/free_function_writer.py
+++ b/cppwg/writers/free_function_writer.py
@@ -20,8 +20,6 @@ class CppFreeFunctionWrapperWriter(CppBaseWrapperWriter):
         The free function information to generate Python bindings for
     wrapper_templates : dict[str, Template]
         Templates with placeholders for generating wrapper code
-    exclusion_args : list[str]
-        A list of argument types to exclude from the wrapper code
     """
 
     def __init__(self, free_function_info, wrapper_templates) -> None:
@@ -29,7 +27,6 @@ class CppFreeFunctionWrapperWriter(CppBaseWrapperWriter):
 
         self.free_function_info: CppFreeFunctionInfo = free_function_info
         self.wrapper_templates: dict[str, "Template"] = wrapper_templates
-        self.exclusion_args: list[str] = []
 
     def generate_wrapper(self) -> str:
         """
@@ -84,17 +81,34 @@ class CppFreeFunctionWrapperWriter(CppBaseWrapperWriter):
         bool
             True if the function should be excluded from wrapper code, False otherwise.
         """
-        # Check if any return types are not wrappable
-        return_type = self.free_function_info.decls[0].return_type.decl_string.replace(
-            " ", ""
+        info = self.free_function_info
+        decl = info.decls[0]
+
+        # Exclude by return type. return_type_excludes targets return types; the
+        # deprecated calldef_excludes applies to both return and arg types.
+        calldef_excludes = info.hierarchy_attribute_gather_flat("calldef_excludes")
+        return_type_excludes = (
+            info.hierarchy_attribute_gather_flat("return_type_excludes")
+            + calldef_excludes
         )
-        if return_type in self.exclusion_args:
+        return_type = decl.return_type.decl_string
+        if any(
+            utils.type_string_matches(return_type, pattern)
+            for pattern in return_type_excludes
+        ):
             return True
 
-        # Check if any arguments not wrappable
-        for decl_arg_type in self.free_function_info.decls[0].argument_types:
-            arg_type = decl_arg_type.decl_string.split()[0].replace(" ", "")
-            if arg_type in self.exclusion_args:
+        # Exclude by argument type. arg_type_excludes is the general arg-type
+        # exclude; the deprecated calldef_excludes applies too.
+        arg_type_excludes = (
+            info.hierarchy_attribute_gather_flat("arg_type_excludes") + calldef_excludes
+        )
+        for argument_type in decl.argument_types:
+            arg_type = argument_type.decl_string
+            if any(
+                utils.type_string_matches(arg_type, pattern)
+                for pattern in arg_type_excludes
+            ):
                 return True
 
         return False

--- a/cppwg/writers/method_writer.py
+++ b/cppwg/writers/method_writer.py
@@ -89,31 +89,35 @@ class CppMethodWrapperWriter(CppBaseWrapperWriter):
         if self.method_decl.parent != self.class_decl:
             return True
 
-        # Check for excluded return types
-        calldef_excludes = [
-            x.replace(" ", "")
-            for x in self.class_info.hierarchy_attribute_gather("calldef_excludes")
-        ]
+        # Exclude by return type. return_type_excludes targets return types;
+        # the deprecated calldef_excludes applies to both return and arg types.
+        calldef_excludes = self.class_info.hierarchy_attribute_gather_flat(
+            "calldef_excludes"
+        )
+        return_type_excludes = (
+            self.class_info.hierarchy_attribute_gather_flat("return_type_excludes")
+            + calldef_excludes
+        )
 
-        return_type_excludes = [
-            x.replace(" ", "")
-            for x in self.class_info.hierarchy_attribute_gather("return_type_excludes")
-        ]
-
-        return_type = self.method_decl.return_type.decl_string.replace(" ", "")
-        if return_type in calldef_excludes or return_type in return_type_excludes:
+        return_type = self.method_decl.return_type.decl_string
+        if any(
+            utils.type_string_matches(return_type, pattern)
+            for pattern in return_type_excludes
+        ):
             return True
 
-        # Check for excluded argument patterns
+        # Exclude by argument type. arg_type_excludes targets argument types on
+        # methods and constructors; the deprecated calldef_excludes applies too.
+        arg_type_excludes = (
+            self.class_info.hierarchy_attribute_gather_flat("arg_type_excludes")
+            + calldef_excludes
+        )
         for argument_type in self.method_decl.argument_types:
-            # e.g. ::std::vector<unsigned int> const & -> ::std::vector<unsigned
-            arg_type_short = argument_type.decl_string.split()[0].replace(" ", "")
-            if arg_type_short in calldef_excludes:
-                return True
-
-            # e.g. ::std::vector<unsigned int> const & -> ::std::vector<unsignedint>const&
-            arg_type_full = argument_type.decl_string.replace(" ", "")
-            if arg_type_full in calldef_excludes:
+            arg_type = argument_type.decl_string
+            if any(
+                utils.type_string_matches(arg_type, pattern)
+                for pattern in arg_type_excludes
+            ):
                 return True
 
         return False

--- a/examples/shapes/wrapper/package_info.yaml
+++ b/examples/shapes/wrapper/package_info.yaml
@@ -70,11 +70,18 @@ modules:
         excluded_methods:
           - ExcludedMethod
 
-        # Exclude any methods that have these arg types.
+        # Exclude any method or constructor with an argument of these types.
+        # Patterns match a type as a whole token (so "Node" won't match
+        # "AbstractNode").
         # arg_type_excludes:
         #   - double
 
-        # Exclude any constructors that have these arg types.
+        # Exclude any method returning these types.
+        # return_type_excludes:
+        #   - double
+
+        # Exclude constructors (only) with an argument of these types, when a
+        # type should be excluded from constructors but not methods.
         # constructor_arg_type_excludes:
         #   - double
 

--- a/tests/test_base_info.py
+++ b/tests/test_base_info.py
@@ -50,3 +50,17 @@ def test_gather_flat_treats_non_str_scalar_as_single_item():
     cls.arg_type_excludes = 5  # nonsensical but yaml-valid scalar
 
     assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == [5]
+
+
+def test_no_config_info_initialises_custom_code_lists():
+    """A config-less info object still has the custom-code list attributes.
+
+    Regression: suffix_code had no default in __init__ (unlike prefix_code and
+    extra_code), so a class built without config (e.g. the use_all_classes
+    path) raised AttributeError when the writer read class_info.suffix_code.
+    """
+    cls = CppClassInfo("Foo")  # constructed with no config
+
+    assert cls.prefix_code == []
+    assert cls.suffix_code == []
+    assert cls.extra_code == []

--- a/tests/test_base_info.py
+++ b/tests/test_base_info.py
@@ -30,3 +30,23 @@ def test_gather_flat_empty_when_unset():
     """An option set nowhere in the hierarchy yields an empty list, not a crash."""
     cls = CppClassInfo("Bar")
     assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == []
+
+
+def test_gather_flat_treats_scalar_as_single_item():
+    """A scalar (str) value is one item, not flattened character by character.
+
+    Guards against a yaml `arg_type_excludes: double` (scalar) being expanded to
+    ['d', 'o', 'u', 'b', 'l', 'e'] and mis-excluding unrelated calldefs.
+    """
+    cls = CppClassInfo("Foo")
+    cls.arg_type_excludes = "double"
+
+    assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == ["double"]
+
+
+def test_gather_flat_treats_non_str_scalar_as_single_item():
+    """Any non-sequence scalar is one item; only list/tuple/set are flattened."""
+    cls = CppClassInfo("Foo")
+    cls.arg_type_excludes = 5  # nonsensical but yaml-valid scalar
+
+    assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == [5]

--- a/tests/test_base_info.py
+++ b/tests/test_base_info.py
@@ -1,0 +1,32 @@
+"""Unit tests for cppwg.info.base_info."""
+
+from cppwg.info.class_info import CppClassInfo
+from cppwg.info.module_info import ModuleInfo
+from cppwg.info.package_info import PackageInfo
+
+
+def test_gather_flat_flattens_list_option_across_hierarchy():
+    """A list-valued option is gathered and flattened from class up to package.
+
+    hierarchy_attribute_gather returns one (list) entry per hierarchy level;
+    hierarchy_attribute_gather_flat merges them into a single list. This is what
+    the writers rely on to collect exclude patterns (and is why consuming the
+    un-flattened result directly used to crash).
+    """
+    package = PackageInfo("pkg", {"source_root": "/src"})
+    module = ModuleInfo("mod")
+    cls = CppClassInfo("Foo")
+    package.add_module(module)
+    module.add_class(cls)
+
+    cls.arg_type_excludes = ["A", "B"]
+    package.arg_type_excludes = ["C"]  # module level left empty
+
+    # Nearest level first, then up the hierarchy.
+    assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == ["A", "B", "C"]
+
+
+def test_gather_flat_empty_when_unset():
+    """An option set nowhere in the hierarchy yields an empty list, not a crash."""
+    cls = CppClassInfo("Bar")
+    assert cls.hierarchy_attribute_gather_flat("arg_type_excludes") == []

--- a/tests/test_class_info.py
+++ b/tests/test_class_info.py
@@ -1,0 +1,22 @@
+"""Unit tests for cppwg.info.class_info."""
+
+from cppwg.info.class_info import CppClassInfo
+
+
+def test_extract_templates_skips_non_dict_substitution(tmp_path):
+    """A mis-typed template_substitutions entry is skipped, not crashed on.
+
+    Each substitution must be a dict with a signature/replacement; a yaml scalar
+    (e.g. `template_substitutions: 5`) would otherwise raise on `entry["..."]`.
+    """
+    source = tmp_path / "Foo.hpp"
+    source.write_text("class Foo {};\n")
+
+    cls = CppClassInfo("Foo")
+    cls.source_file_path = str(source)
+    cls.template_substitutions = [5, "foo"]  # mis-typed scalar entries
+
+    cls.extract_templates_from_source()  # must not raise
+
+    assert cls.template_arg_lists == []
+    assert cls.template_params == []

--- a/tests/test_class_writer.py
+++ b/tests/test_class_writer.py
@@ -52,6 +52,9 @@ class _FakeClassInfo:
         value = self._attrs.get(key)
         return [value] if value else []
 
+    def hierarchy_attribute_gather_flat(self, key):
+        return [item for value in self.hierarchy_attribute_gather(key) for item in value]
+
 
 def _make_writer(class_info):
     """Build a class writer around a fake class info object."""

--- a/tests/test_class_writer.py
+++ b/tests/test_class_writer.py
@@ -256,3 +256,11 @@ def test_bases_block_scalar_external_bases_matches_named_base():
     writer = _external_bases_writer("AbstractFoo")
 
     assert writer.bases_block(class_decl) == ", ::AbstractFoo"
+
+
+def test_bases_block_non_string_scalar_external_bases_is_ignored():
+    """A non-string scalar external_bases is ignored, not crashed on."""
+    class_decl = _BasesDecl([_Base(_RelatedClass("Foo", "::Foo"))])
+    writer = _external_bases_writer(5)  # mis-typed non-string scalar
+
+    assert writer.bases_block(class_decl) == ""

--- a/tests/test_class_writer.py
+++ b/tests/test_class_writer.py
@@ -193,3 +193,66 @@ def test_struct_enum_wrapper_source_includes_and_prefix():
         "}\n"
     )
     assert output == expected
+
+
+def test_includes_block_skips_non_string_source_include():
+    """A mis-typed (non-string) source_includes entry is skipped, not crashed on."""
+    class_info = _FakeClassInfo(
+        "Foo",
+        object(),
+        {"common_include_file": False, "source_includes": [5, "<memory>"]},
+        "Foo.hpp",
+    )
+    writer = _make_writer(class_info)
+
+    assert writer.includes_block() == '#include <memory>\n#include "Foo.hpp"\n'
+
+
+class _RelatedClass:
+    """Stand-in for a pygccxml base's related_class."""
+
+    def __init__(self, name, decl_string):
+        self.name = name
+        self.decl_string = decl_string
+
+
+class _Base:
+    """Stand-in for a pygccxml hierarchy_info_t (a base class entry)."""
+
+    def __init__(self, related_class, access_type="public"):
+        self.related_class = related_class
+        self.access_type = access_type
+
+
+class _BasesDecl:
+    """Stand-in for a class_t exposing .bases."""
+
+    def __init__(self, bases):
+        self.bases = bases
+
+
+def _external_bases_writer(external_bases):
+    class_info = _FakeClassInfo(
+        "X",
+        object(),
+        {"imports": ["mod"], "external_bases": external_bases},
+        "X.hpp",
+    )
+    return _make_writer(class_info)
+
+
+def test_bases_block_scalar_external_bases_does_not_substring_match():
+    """A scalar external_bases is treated as one name, not a substring haystack."""
+    class_decl = _BasesDecl([_Base(_RelatedClass("Foo", "::Foo"))])
+    writer = _external_bases_writer("AbstractFoo")  # mis-typed scalar
+
+    # "Foo" is a substring of "AbstractFoo" but must NOT match.
+    assert writer.bases_block(class_decl) == ""
+
+
+def test_bases_block_scalar_external_bases_matches_named_base():
+    """A scalar external_bases still works as a single external base name."""
+    class_decl = _BasesDecl([_Base(_RelatedClass("AbstractFoo", "::AbstractFoo"))])
+    writer = _external_bases_writer("AbstractFoo")
+
+    assert writer.bases_block(class_decl) == ", ::AbstractFoo"

--- a/tests/test_class_writer.py
+++ b/tests/test_class_writer.py
@@ -1,5 +1,6 @@
 """Unit tests for cppwg.writers.class_writer."""
 
+from cppwg.info.base_info import BaseInfo
 from cppwg.templates.pybind11_default import template_collection
 from cppwg.writers.class_writer import CppClassWrapperWriter
 
@@ -52,8 +53,9 @@ class _FakeClassInfo:
         value = self._attrs.get(key)
         return [value] if value else []
 
-    def hierarchy_attribute_gather_flat(self, key):
-        return [item for value in self.hierarchy_attribute_gather(key) for item in value]
+    # Borrow the production flatten so this double cannot diverge from BaseInfo
+    # (e.g. its scalar handling); it only depends on hierarchy_attribute_gather.
+    hierarchy_attribute_gather_flat = BaseInfo.hierarchy_attribute_gather_flat
 
 
 def _make_writer(class_info):

--- a/tests/test_constructor_writer.py
+++ b/tests/test_constructor_writer.py
@@ -1,0 +1,81 @@
+"""Unit tests for cppwg.writers.constructor_writer exclusion behaviour."""
+
+from cppwg.info.base_info import BaseInfo
+from cppwg.writers import constructor_writer as constructor_writer_module
+from cppwg.writers.constructor_writer import CppConstructorWrapperWriter
+
+
+class _Type:
+    """Stand-in for a pygccxml type (only decl_string is used)."""
+
+    def __init__(self, decl_string):
+        self.decl_string = decl_string
+
+
+class _ClassDecl:
+    """Minimal class_t stand-in for the early checks in exclude()."""
+
+    is_abstract = False
+    recursive_bases = []
+
+    def member_functions(self, allow_empty=True):
+        return []
+
+
+class _CtorDecl:
+    """Minimal constructor_t stand-in."""
+
+    is_artificial = False
+
+    def __init__(self, arg_types, parent):
+        self.argument_types = [_Type(a) for a in arg_types]
+        self.parent = parent
+
+
+class _ClassInfo:
+    """Minimal CppClassInfo stand-in that mirrors production gathering."""
+
+    def __init__(self, signature_excludes=None):
+        self._signature_excludes = signature_excludes
+
+    def hierarchy_attribute_gather(self, name):
+        if name == "constructor_signature_excludes" and self._signature_excludes:
+            return [self._signature_excludes]
+        return []
+
+    # Borrow production so the double cannot diverge (scalar handling etc.).
+    hierarchy_attribute_gather_flat = BaseInfo.hierarchy_attribute_gather_flat
+
+
+def _writer(arg_types, signature_excludes, monkeypatch):
+    # is_copy_constructor inspects a real pygccxml decl; stub it out so exclude()
+    # reaches the signature-exclude loop with our lightweight fakes.
+    monkeypatch.setattr(
+        constructor_writer_module.type_traits_classes,
+        "is_copy_constructor",
+        lambda decl: False,
+    )
+    class_decl = _ClassDecl()
+    writer = object.__new__(CppConstructorWrapperWriter)
+    writer.class_info = _ClassInfo(signature_excludes)
+    writer.class_decl = class_decl
+    writer.ctor_decl = _CtorDecl(arg_types, parent=class_decl)
+    return writer
+
+
+def test_signature_exclude_matches_valid_signature(monkeypatch):
+    """A well-formed nested signature excludes a matching constructor."""
+    writer = _writer(["int", "int", "int"], [["int", "int", "int"]], monkeypatch)
+    assert writer.exclude() is True
+
+
+def test_signature_exclude_skips_scalar_int(monkeypatch):
+    """A mis-typed scalar (constructor_signature_excludes: 5) is skipped, not len()'d."""
+    writer = _writer(["int", "int", "int"], 5, monkeypatch)
+    assert writer.exclude() is False
+
+
+def test_signature_exclude_skips_scalar_string(monkeypatch):
+    """A mis-typed scalar string is skipped, not iterated character by character."""
+    writer = _writer(["int", "int", "int"], "int", monkeypatch)
+    assert writer.exclude() is False

--- a/tests/test_free_function_writer.py
+++ b/tests/test_free_function_writer.py
@@ -1,0 +1,69 @@
+"""Unit tests for cppwg.writers.free_function_writer exclusion behaviour."""
+
+from cppwg.writers.free_function_writer import CppFreeFunctionWrapperWriter
+
+
+class _Type:
+    """Stand-in for a pygccxml type (only decl_string is used)."""
+
+    def __init__(self, decl_string):
+        self.decl_string = decl_string
+
+
+class _Decl:
+    """Minimal free_function_t stand-in."""
+
+    def __init__(self, return_type, arg_types):
+        self.return_type = _Type(return_type)
+        self.argument_types = [_Type(a) for a in arg_types]
+
+
+class _FreeFunctionInfo:
+    """Minimal CppFreeFunctionInfo stand-in for exclusion lookups."""
+
+    def __init__(self, return_type, arg_types, excludes=None):
+        self.decls = [_Decl(return_type, arg_types)]
+        self._excludes = excludes or {}
+
+    def hierarchy_attribute_gather_flat(self, name):
+        return list(self._excludes.get(name, []))
+
+
+def _writer(return_type="void", arg_types=(), excludes=None):
+    info = _FreeFunctionInfo(return_type, list(arg_types), excludes)
+    writer = object.__new__(CppFreeFunctionWrapperWriter)
+    writer.free_function_info = info
+    return writer
+
+
+def test_free_function_arg_type_exclude_respects_boundaries():
+    """arg_type_excludes drops free functions by argument type, as a whole token."""
+    excludes = {"arg_type_excludes": ["Node"]}
+
+    assert _writer(arg_types=["::Node<2> const &"], excludes=excludes).exclude() is True
+    assert (
+        _writer(arg_types=["::AbstractNode<2> const &"], excludes=excludes).exclude()
+        is False
+    )
+
+
+def test_free_function_return_type_exclude():
+    """return_type_excludes drops free functions by return type only."""
+    excludes = {"return_type_excludes": ["RawPtr"]}
+
+    assert _writer(return_type="::RawPtr *", excludes=excludes).exclude() is True
+    assert _writer(return_type="int", excludes=excludes).exclude() is False
+    assert _writer(arg_types=["::RawPtr *"], excludes=excludes).exclude() is False
+
+
+def test_free_function_calldef_exclude_applies_to_both():
+    """The deprecated calldef_excludes matches both return and argument types."""
+    excludes = {"calldef_excludes": ["Foo"]}
+
+    assert _writer(return_type="::Foo &", excludes=excludes).exclude() is True
+    assert _writer(arg_types=["::Foo const &"], excludes=excludes).exclude() is True
+
+
+def test_free_function_not_excluded_without_options():
+    """With no exclusion options set, nothing is excluded."""
+    assert _writer(return_type="int", arg_types=["double"]).exclude() is False

--- a/tests/test_method_writer.py
+++ b/tests/test_method_writer.py
@@ -1,0 +1,70 @@
+"""Unit tests for cppwg.writers.method_writer exclusion behaviour."""
+
+from cppwg.writers.method_writer import CppMethodWrapperWriter
+
+
+class _Type:
+    """Stand-in for a pygccxml type (only decl_string is used)."""
+
+    def __init__(self, decl_string):
+        self.decl_string = decl_string
+
+
+class _Method:
+    """Minimal member_function_t stand-in."""
+
+    def __init__(self, name, return_type, arg_types, parent, access="public"):
+        self.name = name
+        self.return_type = _Type(return_type)
+        self.argument_types = [_Type(a) for a in arg_types]
+        self.access_type = access
+        self.parent = parent
+
+
+class _ClassInfo:
+    """Minimal CppClassInfo stand-in for exclusion lookups."""
+
+    def __init__(self, excludes=None, excluded_methods=None):
+        self._excludes = excludes or {}
+        self.excluded_methods = excluded_methods or []
+
+    def hierarchy_attribute_gather_flat(self, name):
+        return list(self._excludes.get(name, []))
+
+
+def _writer(class_info, return_type="void", arg_types=(), access="public"):
+    class_decl = object()
+    method = _Method("Foo", return_type, list(arg_types), class_decl, access)
+    writer = object.__new__(CppMethodWrapperWriter)
+    writer.class_info = class_info
+    writer.method_decl = method
+    writer.class_decl = class_decl
+    return writer
+
+
+def test_arg_type_exclude_respects_identifier_boundaries():
+    """A method taking the excluded arg type is dropped; a look-alike is kept."""
+    class_info = _ClassInfo(excludes={"arg_type_excludes": ["Node"]})
+
+    assert _writer(class_info, arg_types=["::Node<2> const &"]).exclude() is True
+    assert _writer(class_info, arg_types=["::AbstractNode<2> const &"]).exclude() is False
+    assert _writer(class_info, arg_types=["int"]).exclude() is False
+
+
+def test_return_type_exclude():
+    """return_type_excludes drops methods by return type only."""
+    class_info = _ClassInfo(excludes={"return_type_excludes": ["RawPtr"]})
+
+    assert _writer(class_info, return_type="::RawPtr *").exclude() is True
+    assert _writer(class_info, return_type="int").exclude() is False
+    # A return-type pattern does not exclude on arguments.
+    assert _writer(class_info, arg_types=["::RawPtr *"]).exclude() is False
+
+
+def test_calldef_exclude_applies_to_both_return_and_args():
+    """The deprecated calldef_excludes matches both return and argument types."""
+    class_info = _ClassInfo(excludes={"calldef_excludes": ["Foo"]})
+
+    assert _writer(class_info, return_type="::Foo &").exclude() is True
+    assert _writer(class_info, arg_types=["::Foo const &"]).exclude() is True
+    assert _writer(class_info, return_type="int", arg_types=["double"]).exclude() is False

--- a/tests/test_package_info_parser.py
+++ b/tests/test_package_info_parser.py
@@ -151,8 +151,8 @@ def test_calldef_excludes_emits_deprecation_warning(tmp_path, caplog):
         PackageInfoParser(config_path, str(tmp_path)).parse()
 
     assert any(
-        "calldef_excludes" in record.message and "deprecated" in record.message.lower()
-        for record in caplog.records
+        "calldef_excludes" in message and "deprecated" in message.lower()
+        for message in caplog.messages
     )
 
 
@@ -174,4 +174,4 @@ def test_no_deprecation_warning_for_current_options(tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         PackageInfoParser(config_path, str(tmp_path)).parse()
 
-    assert not any("deprecated" in record.message.lower() for record in caplog.records)
+    assert not any("deprecated" in message.lower() for message in caplog.messages)

--- a/tests/test_package_info_parser.py
+++ b/tests/test_package_info_parser.py
@@ -1,5 +1,6 @@
 """Unit tests for cppwg.parsers.package_info_parser."""
 
+import logging
 import os
 import textwrap
 
@@ -129,3 +130,48 @@ def test_module_external_bases_default_to_empty_list(tmp_path):
 
     module_info = package_info.module_collection[0]
     assert module_info.external_bases == []
+
+
+def test_calldef_excludes_emits_deprecation_warning(tmp_path, caplog):
+    """A deprecated calldef_excludes option triggers a deprecation warning."""
+    config_path = _write_config(
+        tmp_path,
+        """
+        name: testpkg
+        modules:
+          - name: mymod
+            classes:
+              - name: Foo
+                calldef_excludes:
+                  - double
+        """,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        PackageInfoParser(config_path, str(tmp_path)).parse()
+
+    assert any(
+        "calldef_excludes" in record.message and "deprecated" in record.message.lower()
+        for record in caplog.records
+    )
+
+
+def test_no_deprecation_warning_for_current_options(tmp_path, caplog):
+    """The replacement option arg_type_excludes does not warn."""
+    config_path = _write_config(
+        tmp_path,
+        """
+        name: testpkg
+        modules:
+          - name: mymod
+            classes:
+              - name: Foo
+                arg_type_excludes:
+                  - double
+        """,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        PackageInfoParser(config_path, str(tmp_path)).parse()
+
+    assert not any("deprecated" in record.message.lower() for record in caplog.records)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,11 @@ from cppwg.utils.utils import type_string_matches, write_file_if_changed
         # Patterns whose edge is not an identifier char still match
         ("::std::vector<int> const &", "std::vector<int>", True),
         ("int *", "int", True),
+        # A pattern ending in a non-identifier char (>) still matches even when
+        # immediately followed by an identifier char (no space before const).
+        ("std::vector<int>const &", "std::vector<int>", True),
+        # A pattern ending in an identifier char still requires a boundary.
+        ("intx", "int", False),
         # Empty pattern never matches
         ("int", "", False),
         # Non-string patterns (e.g. yaml scalars like `arg_type_excludes: 5`)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,37 @@
 
 import os
 
-from cppwg.utils.utils import write_file_if_changed
+import pytest
+
+from cppwg.utils.utils import type_string_matches, write_file_if_changed
+
+
+@pytest.mark.parametrize(
+    "type_string, pattern, expected",
+    [
+        # Whole-token identifier matches (not part of a larger identifier)
+        ("::Node<2> const &", "Node", True),
+        ("::AbstractNode<2> const &", "Node", False),
+        ("Node", "Node", True),
+        ("NodeIterator", "Node", False),
+        ("MyNode", "Node", False),
+        # Qualified / templated names
+        ("::std::vector<Node> const &", "Node", True),
+        ("boost::shared_ptr<Foo>", "boost::shared_ptr", True),
+        ("myboost::shared_ptr<Foo>", "boost::shared_ptr", False),
+        # Multi-token type names
+        ("unsigned int const &", "unsigned int", True),
+        ("unsigned integer", "unsigned int", False),
+        # Patterns whose edge is not an identifier char still match
+        ("::std::vector<int> const &", "std::vector<int>", True),
+        ("int *", "int", True),
+        # Empty pattern never matches
+        ("int", "", False),
+    ],
+)
+def test_type_string_matches(type_string, pattern, expected):
+    """Type patterns match as whole tokens, respecting identifier boundaries."""
+    assert type_string_matches(type_string, pattern) is expected
 
 
 def test_writes_when_file_missing(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,10 @@ from cppwg.utils.utils import type_string_matches, write_file_if_changed
         ("int *", "int", True),
         # Empty pattern never matches
         ("int", "", False),
+        # Non-string patterns (e.g. yaml scalars like `arg_type_excludes: 5`)
+        # are non-matching rather than crashing on re.escape.
+        ("5", 5, False),
+        ("int", True, False),
     ],
 )
 def test_type_string_matches(type_string, pattern, expected):


### PR DESCRIPTION
### Summary

Consolidate and clarify arg and return type exclusion config options:
- `calldef_excludes`: Excludes methods (including constructors) with specified arg types, as well as return types. This dual function (exclusion by both arg type and return type) is not clear from the name. Now on a deprecation path, replaced by the more intuitively named `arg_type_excludes` and `return_type_excludes` below.
- `arg_type_excludes`: Documented but inactive, now revived to exclude methods (including constructors) with specified arg types.
- `return_type_excludes`: Documented but buggy (raised an `AttributeError`), now fixed to exclude methods with specified return types.
- `constructor_arg_type_excludes`: Retained as a constructor-only refinement of `arg_type_excludes`.
- `constructor_signature_excludes`: Retained to exclude constructors matched by their full signature.
- `free_function_writer.exclusion_args`: Documented but inactive, now replaced with `arg_type_excludes` and `return_type_excludes` as above.
- Matching bug: Type matching is now boundary-aware everywhere so as not to conflate distinct types (e.g. `Node` matches `::Node<2> const &` but not `AbstractNode`).


