### PR TITLE
Remove the unused extra_code config option

### DIFF
--- a/cppwg/info/base_info.py
+++ b/cppwg/info/base_info.py
@@ -45,8 +45,6 @@ class BaseInfo(ABC):
         Do not include these methods.
     excluded_variables : list[str]
         Do not include these variables.
-    extra_code : list[str]
-        Any extra wrapper code for the feature.
     name : str
         The name of the package, module, class etc. represented by this object.
     name_replacements : dict[str, str]
@@ -127,7 +125,6 @@ class BaseInfo(ABC):
         }
 
         # Custom Code
-        self.extra_code: list[str] = []
         self.prefix_code: list[str] = []
         self.suffix_code: list[str] = []
         self.prefix_text: str = ""
@@ -145,7 +142,6 @@ class BaseInfo(ABC):
                 "excluded",
                 "excluded_methods",
                 "excluded_variables",
-                "extra_code",
                 "name_replacements",
                 "pointer_call_policy",
                 "prefix_code",

--- a/cppwg/parsers/package_info_parser.py
+++ b/cppwg/parsers/package_info_parser.py
@@ -65,7 +65,6 @@ class PackageInfoParser:
             "excluded": False,
             "excluded_methods": [],
             "excluded_variables": [],
-            "extra_code": [],
             "pointer_call_policy": "",
             "prefix_code": [],
             "prefix_text": "",

--- a/tests/test_base_info.py
+++ b/tests/test_base_info.py
@@ -55,12 +55,11 @@ def test_gather_flat_treats_non_str_scalar_as_single_item():
 def test_no_config_info_initialises_custom_code_lists():
     """A config-less info object still has the custom-code list attributes.
 
-    Regression: suffix_code had no default in __init__ (unlike prefix_code and
-    extra_code), so a class built without config (e.g. the use_all_classes
-    path) raised AttributeError when the writer read class_info.suffix_code.
+    Regression: suffix_code had no default in __init__ (unlike prefix_code), so
+    a class built without config (e.g. the use_all_classes path) raised
+    AttributeError when the writer read class_info.suffix_code.
     """
     cls = CppClassInfo("Foo")  # constructed with no config
 
     assert cls.prefix_code == []
     assert cls.suffix_code == []
-    assert cls.extra_code == []


### PR DESCRIPTION
### Summary

This removes the inactive `extra_code` option that is accepted in config but has never been implemented historically. It currently has no effect and is ignored by the parser. The active `suffix_code`  (which pairs with the `prefix_code`) option delivers the necessary functionality of adding extra custom code to generated bindings.