### PR TITLE
#99 Rename get_source_includes hook to get_class_cpp_source_includes

### DIFF
--- a/cppwg/templates/custom.py
+++ b/cppwg/templates/custom.py
@@ -25,7 +25,7 @@ class Custom:
 
         return ""
 
-    def get_source_includes(self, *args, **kwargs) -> list:
+    def get_class_cpp_source_includes(self, *args, **kwargs) -> list:
         """
         Return headers to add to the #include block of the class wrapper.
 

--- a/cppwg/writers/class_writer.py
+++ b/cppwg/writers/class_writer.py
@@ -167,12 +167,12 @@ class CppClassWrapperWriter(CppBaseWrapperWriter):
         # Headers a custom generator's emitted code needs. A generator can name
         # types in its get_class_cpp_def_code() output that never appear in the
         # parsed signatures (e.g. AddCellWriter<CellAgesWriter>), so cppwg cannot
-        # auto-detect them; it declares them via the optional get_source_includes()
+        # auto-detect them; it declares them via the optional get_class_cpp_source_includes()
         # hook. These are emitted before the common-include early return: they may
         # be <...> system headers or otherwise absent from the wrapper header
         # collection, so the header collection alone would not pull them in.
         for header in call_generator_hook(
-            self.class_info.custom_generator_instance, "get_source_includes", []
+            self.class_info.custom_generator_instance, "get_class_cpp_source_includes", []
         ):
             add(self._format_include(header))
 

--- a/doc/custom-generators.md
+++ b/doc/custom-generators.md
@@ -25,7 +25,7 @@ class; module-level hooks fire for one set on a module.
 | --- | --- | --- | --- |
 | `get_class_cpp_pre_code(class_name)` | class | Code before the registration block | Before `py::class_<...>` |
 | `get_class_cpp_def_code(class_name)` | class | Extra `.def(...)` lines | Into the `.def` chain |
-| `get_source_includes()` | class | Header names the emitted code needs | The wrapper `#include` block |
+| `get_class_cpp_source_includes()` | class | Header names the emitted code needs | The wrapper `#include` block |
 | `get_module_pre_code()` | module | Top-of-file code | Before the class includes |
 | `get_module_code()` | module | Module-body code | Before the end of `PYBIND11_MODULE` |
 
@@ -56,11 +56,11 @@ class MeshCollectionTemplate(cppwg.templates.custom.Custom):
 Code emitted by a generator can reference types that never appear in the parsed
 signatures, so [`auto_includes`](includes.md#auto_includes) cannot resolve their
 headers, and they would otherwise have to be listed manually under
-`source_includes`. Override `get_source_includes()` on the same generator to
+`source_includes`. Override `get_class_cpp_source_includes()` on the same generator to
 declare them:
 
 ```python
-    def get_source_includes(self, *args, **kwargs):
+    def get_class_cpp_source_includes(self, *args, **kwargs):
         return [f"{m}.hpp" for m in self.MESHES]
 ```
 

--- a/tests/test_class_writer.py
+++ b/tests/test_class_writer.py
@@ -284,7 +284,7 @@ class _FakeGenerator:
     def get_class_cpp_def_code(self, class_py_name):
         return ""
 
-    def get_source_includes(self, *args, **kwargs):
+    def get_class_cpp_source_includes(self, *args, **kwargs):
         return []
 
 
@@ -564,12 +564,12 @@ class _SourceIncludeGen:
     def __init__(self, headers):
         self._headers = headers
 
-    def get_source_includes(self, *args, **kwargs):
+    def get_class_cpp_source_includes(self, *args, **kwargs):
         return self._headers
 
 
 def test_includes_block_emits_generator_source_includes():
-    """A custom generator's get_source_includes() headers are added to the block.
+    """A custom generator's get_class_cpp_source_includes() headers are added to the block.
 
     Covers the category the auto-include detection cannot see: types named only
     in the generator's emitted code (e.g. AddCellWriter<CellAgesWriter>), whose
@@ -610,7 +610,7 @@ def test_includes_block_dedups_generator_and_source_includes():
 
 
 def test_includes_block_generator_without_source_includes_hook():
-    """A legacy generator lacking get_source_includes() does not break generation.
+    """A legacy generator lacking get_class_cpp_source_includes() does not break generation.
 
     Generators that only implement the pre/def-code methods (and do not subclass
     Custom) must keep working - the optional hook is skipped, not required.
@@ -637,7 +637,7 @@ def test_includes_block_generator_without_source_includes_hook():
 
 
 def test_includes_block_emits_generator_source_includes_in_common():
-    """Generator get_source_includes() headers are emitted even in common mode.
+    """Generator get_class_cpp_source_includes() headers are emitted even in common mode.
 
     They can be <...> system headers or category-D headers (named only in the
     generator's emitted code) that wrapper_header_collection.cppwg.hpp does not

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -370,7 +370,7 @@ def test_call_generator_hook():
     assert call_generator_hook(gen, "get_class_cpp_pre_code", "", "Foo") == "// Foo"
 
     # A missing hook (generator does not subclass Custom / omits it) -> default.
-    assert call_generator_hook(gen, "get_source_includes", []) == []
+    assert call_generator_hook(gen, "get_class_cpp_source_includes", []) == []
     assert call_generator_hook(gen, "get_class_cpp_def_code", "", "Foo") == ""
 
     # No generator at all -> default.


### PR DESCRIPTION
Follow up to #99.

Align the custom-generator include hook with its siblings (get_class_cpp_pre_code, get_class_cpp_def_code): it is class-scoped and targets the .cppwg.cpp include block, so the name now carries both the class scope and cpp file tokens..