### PR TITLE
Fix logging regressions

### DIFF
--- a/.github/workflows/test-cells-conda.yml
+++ b/.github/workflows/test-cells-conda.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check for changes
         run: |
           git diff --exit-code dynamic/wrappers
-          grep "Unknown class" build/cppwg_*.log
+          grep "Unknown class" build/cppwg.log
         working-directory: examples/cells
 
       - name: Build

--- a/.github/workflows/test-cells-ubuntu.yml
+++ b/.github/workflows/test-cells-ubuntu.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Check for changes
         run: |
           git diff --exit-code dynamic/wrappers
-          grep "Unknown class" build/cppwg_*.log
+          grep "Unknown class" build/cppwg.log
         working-directory: examples/cells
 
       - name: Create build env

--- a/.github/workflows/test-shapes-pip.yml
+++ b/.github/workflows/test-shapes-pip.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Check for changes
         run: |
           git diff --exit-code wrapper
-          grep "Unknown class" cppwg_*.log
+          grep "Unknown class" cppwg.log
         working-directory: examples/shapes
 
       - name: Configure

--- a/cppwg/__main__.py
+++ b/cppwg/__main__.py
@@ -9,26 +9,37 @@ from cppwg import CppWrapperGenerator
 from cppwg.version import __version__
 
 
-def timestamped_logfile(logfile: str) -> str:
+def rotate_logfile(logfile: str) -> None:
     """
-    Insert a timestamp into a log filename so each run writes a separate file.
+    Rotate an existing log file out of the way so the next run can reuse its name.
 
-    e.g. "cppwg.log" -> "cppwg_20260708-153012.log". This keeps a log per run
-    rather than overwriting a single file, so earlier runs can be compared.
+    If a log file already exists at the path, it is renamed with its own
+    last-modification time inserted before the suffix, e.g.
+    "cppwg.log" -> "cppwg_20260708-153012.log". The new run then writes to the
+    original name, so the requested path always holds the latest run while
+    earlier runs are preserved under timestamped names. A trailing "-N" is added
+    if a log with that timestamp already exists, so a previous run is never
+    overwritten (and the rename does not raise on Windows, where it would not
+    replace an existing destination). Non-file paths (e.g. a directory) are left
+    untouched.
 
     Parameters
     ----------
     logfile : str
         The requested log file path.
-
-    Returns
-    -------
-    str
-        The path with a "_YYYYmmdd-HHMMSS" timestamp inserted before the suffix.
     """
     path = Path(logfile)
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    return str(path.with_name(f"{path.stem}_{timestamp}{path.suffix}"))
+    if not path.is_file():
+        return
+
+    timestamp = datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y%m%d-%H%M%S")
+    rotated = path.with_name(f"{path.stem}_{timestamp}{path.suffix}")
+    counter = 1
+    while rotated.exists():
+        rotated = path.with_name(f"{path.stem}_{timestamp}-{counter}{path.suffix}")
+        counter += 1
+
+    path.rename(rotated)
 
 
 def parse_args() -> argparse.Namespace:
@@ -196,8 +207,10 @@ def main() -> None:
 
     logfile = None
     if args.logfile:
-        # Write a separate, timestamped log file per run rather than overwriting.
-        logfile = timestamped_logfile(args.logfile)
+        # Write to the requested path, rotating any existing log out of the way
+        # first so previous runs are preserved under timestamped names.
+        logfile = args.logfile
+        rotate_logfile(logfile)
         file_handler = logging.FileHandler(logfile, "w")
         file_handler.setLevel(logging.INFO)
         log_handlers.append(file_handler)

--- a/cppwg/info/package_info.py
+++ b/cppwg/info/package_info.py
@@ -750,9 +750,13 @@ class PackageInfo(BaseInfo):
                     base.related_class for decl in keep_decls for base in decl.bases
                 ]
 
-            # Drop classes left with no instantiations to wrap
+            # Drop classes left with no instantiations to wrap. Excluded classes
+            # are kept: they carry no cpp_names (the writers skip them) but must
+            # stay in the collection so they remain known - otherwise
+            # log_unknown_classes would report an explicitly excluded class as an
+            # unwrapped one.
             module_info.class_collection = [
-                c for c in module_info.class_collection if c.cpp_names
+                c for c in module_info.class_collection if c.cpp_names or c.excluded
             ]
 
     def _module_source_locations(self) -> list[Path]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,41 +1,75 @@
 """Unit tests for cppwg.__main__."""
 
+import os
 import re
+from datetime import datetime
 
-from cppwg.__main__ import timestamped_logfile
-
-
-def test_timestamped_logfile_inserts_timestamp():
-    """A timestamp is inserted before the suffix, keeping the directory/stem."""
-    result = timestamped_logfile("/var/log/cppwg.log")
-    assert re.fullmatch(r"/var/log/cppwg_\d{8}-\d{6}\.log", result)
+from cppwg.__main__ import rotate_logfile
 
 
-def test_timestamped_logfile_bare_name():
-    """A bare filename (no directory) is handled."""
-    result = timestamped_logfile("cppwg.log")
-    assert re.fullmatch(r"cppwg_\d{8}-\d{6}\.log", result)
+def test_rotate_logfile_absent_is_noop(tmp_path):
+    """A missing log file needs no rotation and leaves the directory empty."""
+    logfile = tmp_path / "cppwg.log"
+    rotate_logfile(str(logfile))
+    assert not logfile.exists()
+    assert list(tmp_path.iterdir()) == []
 
 
-def test_timestamped_logfile_unique_per_call(monkeypatch):
-    """Successive runs (different times) produce different filenames."""
-    from cppwg import __main__ as main_module
+def test_rotate_logfile_renames_existing_by_mtime(tmp_path):
+    """An existing log is renamed with its own mtime inserted before the suffix."""
+    logfile = tmp_path / "cppwg.log"
+    logfile.write_text("previous run")
 
-    times = iter(["20260708-153012", "20260708-153030"])
+    # Pin the modification time so the rotated name is deterministic.
+    mtime = datetime(2026, 7, 8, 15, 30, 12).timestamp()
+    os.utime(logfile, (mtime, mtime))
 
-    class _FixedDatetime:
-        @staticmethod
-        def now():
-            class _Now:
-                @staticmethod
-                def strftime(fmt):
-                    return next(times)
+    rotate_logfile(str(logfile))
 
-            return _Now()
+    assert not logfile.exists()
+    rotated = tmp_path / "cppwg_20260708-153012.log"
+    assert rotated.exists()
+    assert rotated.read_text() == "previous run"
 
-    monkeypatch.setattr(main_module, "datetime", _FixedDatetime)
-    first = timestamped_logfile("cppwg.log")
-    second = timestamped_logfile("cppwg.log")
-    assert first == "cppwg_20260708-153012.log"
-    assert second == "cppwg_20260708-153030.log"
-    assert first != second
+
+def test_rotate_logfile_keeps_stem_and_suffix(tmp_path):
+    """Rotation preserves the stem and suffix around the inserted timestamp."""
+    logfile = tmp_path / "cppwg.log"
+    logfile.write_text("x")
+
+    rotate_logfile(str(logfile))
+
+    assert not logfile.exists()
+    contents = list(tmp_path.iterdir())
+    assert len(contents) == 1
+    assert re.fullmatch(r"cppwg_\d{8}-\d{6}\.log", contents[0].name)
+
+
+def test_rotate_logfile_does_not_overwrite_same_timestamp(tmp_path):
+    """A rotated name that already exists is disambiguated, never overwritten."""
+    logfile = tmp_path / "cppwg.log"
+    logfile.write_text("newer run")
+    mtime = datetime(2026, 7, 8, 15, 30, 12).timestamp()
+    os.utime(logfile, (mtime, mtime))
+
+    # A previous run already rotated to this exact mtime-second name.
+    existing = tmp_path / "cppwg_20260708-153012.log"
+    existing.write_text("older run")
+
+    rotate_logfile(str(logfile))
+
+    assert not logfile.exists()
+    assert existing.read_text() == "older run"  # untouched
+    disambiguated = tmp_path / "cppwg_20260708-153012-1.log"
+    assert disambiguated.read_text() == "newer run"
+
+
+def test_rotate_logfile_ignores_directory(tmp_path):
+    """A directory at the log path is left untouched, not renamed."""
+    logdir = tmp_path / "cppwg.log"
+    logdir.mkdir()
+
+    rotate_logfile(str(logdir))
+
+    assert logdir.is_dir()
+    assert [p.name for p in tmp_path.iterdir()] == ["cppwg.log"]

--- a/tests/test_package_info.py
+++ b/tests/test_package_info.py
@@ -353,6 +353,28 @@ def test_prune_ignores_dependency_reached_only_through_excluded_method():
     assert cls.cpp_names == ["VertexMesh<1, 2>", "VertexMesh<2, 2>"]
 
 
+def test_prune_keeps_excluded_class_without_instantiations():
+    """An excluded class carries no cpp_names but must survive pruning.
+
+    Excluded classes are never given cpp_names, so the no-instantiations drop
+    would otherwise remove them - and log_unknown_classes would then report an
+    explicitly excluded class as an unwrapped one. A non-excluded class with no
+    instantiations is still dropped.
+    """
+    package, excluded = _package_with_class("StepSizeException")
+    excluded.excluded = True
+
+    module = package.module_collection[0]
+    never_instantiated = CppClassInfo("NeverInstantiated")
+    module.add_class(never_instantiated)
+
+    package.prune_uninstantiated_dependencies(restricted_paths=[])
+
+    names = [c.name for c in module.class_collection]
+    assert "StepSizeException" in names
+    assert "NeverInstantiated" not in names
+
+
 def test_prune_flags_uninstantiated_enclosing_template():
     """An uninstantiated enclosing template is flagged, not just its arguments."""
     package, cls = _package_with_class("Widget")


### PR DESCRIPTION
### Changes

- Rotate logfiles instead of overwriting, renaming the existing one out of the way with the relevant timestamp.
- Keep excluded classes long enough for `log_unknown_classes` to see them.